### PR TITLE
Task-3-PostgreSQL-&-Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM maven:3-amazoncorretto-21-alpine AS build
+
+WORKDIR /app
+
+COPY pom.xml .
+
+RUN mvn dependency:go-offline -B
+
+COPY src ./src
+
+RUN mvn clean package -DskipTests
+
+FROM openjdk:21-slim
+
+WORKDIR /app
+
+COPY --from=build /app/target/disaster-alerts-0.0.1-SNAPSHOT.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar", "--spring.profiles.active=prod"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,1 +1,34 @@
 services:
+  app:
+    container_name: MainApp
+    build:
+      context: ./
+    ports:
+      - "8081:8080"
+    depends_on:
+      - db
+    restart: always
+    networks:
+      - disaster-net
+
+  db:
+    image: postgres:16.3
+    container_name: Database
+    environment:
+      POSTGRES_DB: disasterdb
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+    restart: always
+    networks:
+      - disaster-net
+
+networks:
+  disaster-net:
+    driver: bridge
+
+volumes:
+  db_data:

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,16 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: Disaster Alerts
+
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://db:5432/disasterdb
+    username: user
+    password: pass
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
Dodałem konfigurację produkcyjną dla Dockera, w tym Docker Compose i Dockerfile.

- Skonfigurowano Docker Compose:
  - Zdefiniowano usługę `app`, budowaną z bieżącego katalogu, wystawioną na porcie 8081 (mapowaną na port 8080 w kontenerze), połączoną z usługą PostgreSQL `db`.
  - Ustawiono usługę `db` używającą obrazu `postgres:16.3`, wystawioną na porcie 5433 (mapowaną na port 5432 w kontenerze), połączoną z siecią `disaster-net`.
  - Skonfigurowano wolumeny dla trwałego przechowywania danych bazy danych przy użyciu `db_data`.
  - Utworzono niestandardową sieć Docker o nazwie `disaster-net` do komunikacji między usługami.
- Zaktualizowano Dockerfile:
  - Zbudowano aplikację przy użyciu Maven z Amazon Corretto 21.
  - Utworzono wieloetapowy build Docker:
    - Pierwszy etap kompiluje aplikację przy użyciu Maven, z pominięciem testów.
    - Drugi etap używa obrazu OpenJDK 21-slim do utworzenia lekkiego obrazu dla aplikacji.
  - Skonfigurowano kontener do uruchomienia aplikacji z profilem `prod`.
- Zaktualizowano `application.yml` dla produkcji:
  - Skonfigurowano datasource PostgreSQL oraz szczegóły połączenia.
  - Ustawiono Hibernate do walidacji schematu oraz użycie dialektu PostgreSQL.
- Zmieniono domyślne porty dla aplikacji i PostgreSQL (8080 → 8081, 5432 → 5433), aby uniknąć konfliktów z lokalnymi usługami.

Całość można zbudować klikająć
![image](https://github.com/user-attachments/assets/b47a8ae2-882a-4690-a02a-95f5f53c1d94)
w compose.yaml

W Dockerze powinniscie mieć taki widok
![image](https://github.com/user-attachments/assets/b9a5d532-6dac-4baa-91d7-1ec889a13a25)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208512402754883