### PR TITLE
Task 36 ci/cd

### DIFF
--- a/.github/workflows/self-host-CD.yml
+++ b/.github/workflows/self-host-CD.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Delete old docker container
         run: sudo docker rm -f disaster-alert-container || true
       - name: Run new docker container
-        run: sudo docker run -d -p 8080:8080 --name disaster-alert-container jkuznik/disaster-alert
+        run: sudo docker run -d -p 8080:8080 --name disaster-alert-container --network disaster-net jkuznik/disaster-alert

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /app
 
 COPY --from=build /app/target/disaster-alerts-0.0.1-SNAPSHOT.jar app.jar
 
-ENTRYPOINT ["java", "-jar", "/app/app.jar", "--spring.profiles.active=prod"]
+ENTRYPOINT ["java", "-jar", "/app/app.jar", "--spring.profiles.active=prod", "--spring.profiles.include="]

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,7 +4,7 @@ spring:
 
   docker:
     compose:
-      file: compose.yaml
+      file: compose-dev.yaml
 
   datasource:
     driver-class-name: org.postgresql.Driver
@@ -21,3 +21,19 @@ spring:
   liquibase:
     change-log: db/changelog-prod.yaml
     contexts: prod
+
+  ai:
+    openai:
+      api-key: "${{ secrets.OPENAI_API_KEY }}"
+      chat:
+        options:
+          model: gpt-4o
+          temperature: 0.5
+
+server:
+  port: 8080
+
+openweathermap:
+  api:
+    key: 3261c3b28f5aed55fcca580f4d7744d0
+    url: https://api.openweathermap.org/data/2.5/weather

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,7 +4,7 @@ spring:
 
   docker:
     compose:
-      file: compose-dev.yaml
+      file: compose.yaml
 
   datasource:
     driver-class-name: org.postgresql.Driver
@@ -19,7 +19,7 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
   liquibase:
-    change-log: db/changelog-prod.yaml
+    change-log: db/changelog-dev.yaml
     contexts: prod
 
   ai:


### PR DESCRIPTION
Zmieniona ścieżka changelogow w pliku application-prod na taką samą jak na profilu 'dev' po to żeby nie kopiować zawartości pliku changelog-dev.sql do changelog-prod.sql - wydaje mi się że ten plik powinien być jednakowy dla różnych profili żeby nie utrzymywać tego dla różnych profili a ewentualnie sama baza danych może być inna dla każdego profilu

Do application-prod dodane są też niezbędne konfigurację do poprawnego działania aplikacji z profilem prod

Co do samego ci/cd to jest zmiana w uruchamianiu kontenera dockerowego na hoscie w taki sposób aby uruchamiał się w jednej sieci dockerowej z kontenerem na którym działa baza danych na hoscie. 

Nie próbowałem jeszcze czy działa ale usunąłem wszystkie znane mi powody czemu za pierwszym razem nie zadziałało, jak ten ci/cd sie nie uda po mergu do master to zacznę testy na osobnym repo