### PR TITLE
Rollback to base setting of RiskAssessment

### DIFF
--- a/src/main/java/pl/ateam/disasteralerts/airiskassessment/RiskAssessmentService.java
+++ b/src/main/java/pl/ateam/disasteralerts/airiskassessment/RiskAssessmentService.java
@@ -10,7 +10,7 @@ import pl.ateam.disasteralerts.disasteralert.dto.DisasterAddDTO;
 @Slf4j
 class RiskAssessmentService {
 
-    public static final double RISK_THRESHOLD = 0.1;
+    public static final double RISK_THRESHOLD = 0.7;
     private final OpenAIClient openAIClient;
 
     boolean assessRisk(DisasterAddDTO disasterAddDTO) {

--- a/src/main/java/pl/ateam/disasteralerts/disasteralert/DisasterServiceImpl.java
+++ b/src/main/java/pl/ateam/disasteralerts/disasteralert/DisasterServiceImpl.java
@@ -24,14 +24,18 @@ class DisasterServiceImpl implements DisasterService {
     public DisasterDTO createDisaster(DisasterAddDTO disasterAddDTO, String source) {
         Disaster disaster = mapper.mapDisasterAddDtoToDisaster(disasterAddDTO);
         disaster.setSource(source);
-        if (riskAssessment.assessRisk(disasterAddDTO)) {
-            disaster.setStatus(DisasterStatus.ACTIVE);
-            disasterRepository.save(disaster);
-            generateAlert(disaster.getId());
-        } else {
-            disaster.setStatus(DisasterStatus.FAKE);
-            disasterRepository.save(disaster);
-        }
+//        if (riskAssessment.assessRisk(disasterAddDTO)) {
+//            disaster.setStatus(DisasterStatus.ACTIVE);
+//            disasterRepository.save(disaster);
+//            generateAlert(disaster.getId());
+//        } else {
+//            disaster.setStatus(DisasterStatus.FAKE);
+//            disasterRepository.save(disaster);
+//        }
+
+        disaster.setStatus(DisasterStatus.ACTIVE);
+        disasterRepository.save(disaster);
+        generateAlert(disaster.getId());
 
         return mapper.mapDisasterToDisasterDto(disaster);
     }

--- a/src/test/java/pl/ateam/disasteralerts/airiskassessment/RiskAssessmentServiceTest.java
+++ b/src/test/java/pl/ateam/disasteralerts/airiskassessment/RiskAssessmentServiceTest.java
@@ -33,51 +33,51 @@ class RiskAssessmentServiceTest {
 
     private final List<String> citiesInPoland = CitiesInPoland.getList();
 
-//    @Test
-//    void shouldReturnTrueWhenRiskScoreAboveThreshold() {
-//        // given
-//        DisasterAddDTO disasterAddDTO = new DisasterAddDTO(
-//                DisasterType.FLOOD,
-//                FLOOD_DESCRIPTION,
-//                citiesInPoland.get(1),
-//                UUID.randomUUID());
-//
-//        // when
-//        when(openAIClient.getRiskScore(Mockito.anyString())).thenReturn(PROBABILITY_OF_RISK_HIGH);
-//
-//        // then
-//        assertTrue(riskAssessmentService.assessRisk(disasterAddDTO));
-//    }
-//
-//    @Test
-//    void shouldReturnFalseWhenRiskScoreBelowThreshold() {
-//        // given
-//        DisasterAddDTO disasterAddDTO = new DisasterAddDTO(
-//                DisasterType.FIRE,
-//                FIRE_DESCRIPTION,
-//                citiesInPoland.get(1),
-//                UUID.randomUUID());
-//
-//        // when
-//        when(openAIClient.getRiskScore(Mockito.anyString())).thenReturn(PROBABILITY_OF_RISK_LOW);
-//
-//        // then
-//        assertFalse(riskAssessmentService.assessRisk(disasterAddDTO));
-//    }
-//
-//    @Test
-//    void shouldReturnFalseWhenOpenAIClientThrowsException() {
-//        // given
-//        DisasterAddDTO disasterAddDTO = new DisasterAddDTO(
-//                DisasterType.FIRE,
-//                FIRE_DESCRIPTION,
-//                citiesInPoland.get(1),
-//                UUID.randomUUID());
-//
-//        // when
-//        when(openAIClient.getRiskScore(Mockito.anyString())).thenThrow(new RuntimeException("Connection error"));
-//
-//        //then
-//        assertFalse(riskAssessmentService.assessRisk(disasterAddDTO));
-//    }
+    @Test
+    void shouldReturnTrueWhenRiskScoreAboveThreshold() {
+        // given
+        DisasterAddDTO disasterAddDTO = new DisasterAddDTO(
+                DisasterType.FLOOD,
+                FLOOD_DESCRIPTION,
+                citiesInPoland.get(1),
+                UUID.randomUUID());
+
+        // when
+        when(openAIClient.getRiskScore(Mockito.anyString())).thenReturn(PROBABILITY_OF_RISK_HIGH);
+
+        // then
+        assertTrue(riskAssessmentService.assessRisk(disasterAddDTO));
+    }
+
+    @Test
+    void shouldReturnFalseWhenRiskScoreBelowThreshold() {
+        // given
+        DisasterAddDTO disasterAddDTO = new DisasterAddDTO(
+                DisasterType.FIRE,
+                FIRE_DESCRIPTION,
+                citiesInPoland.get(1),
+                UUID.randomUUID());
+
+        // when
+        when(openAIClient.getRiskScore(Mockito.anyString())).thenReturn(PROBABILITY_OF_RISK_LOW);
+
+        // then
+        assertFalse(riskAssessmentService.assessRisk(disasterAddDTO));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOpenAIClientThrowsException() {
+        // given
+        DisasterAddDTO disasterAddDTO = new DisasterAddDTO(
+                DisasterType.FIRE,
+                FIRE_DESCRIPTION,
+                citiesInPoland.get(1),
+                UUID.randomUUID());
+
+        // when
+        when(openAIClient.getRiskScore(Mockito.anyString())).thenThrow(new RuntimeException("Connection error"));
+
+        //then
+        assertFalse(riskAssessmentService.assessRisk(disasterAddDTO));
+    }
 }


### PR DESCRIPTION
Powrót początkowych ustawień RiskAssessment ale tymczasowo wyłączenie tej funkcji żeby spróbować działanie wysylania sms po dodaniu zdarzenia z statusem ACTIVE. 

Przy wcześniejszych próbach z działającym RiskAssessmentem nie udało się utworzyć zdarzenia z statusem ACTIVE pomimo podmiany wymagania na 0.1 w ocenie zagrożenia przez AI 